### PR TITLE
Fix: Updated get_n_zeros to round up.

### DIFF
--- a/rigl/sparse_utils.py
+++ b/rigl/sparse_utils.py
@@ -33,7 +33,7 @@ def mask_extract_name_fn(mask_name):
 
 
 def get_n_zeros(size, sparsity):
-  return int(np.floor(sparsity * size))
+  return int(round(sparsity * size))
 
 
 def calculate_sparsity(masks):


### PR DESCRIPTION
Hi @evcu  :wave: ,

I saw `np.floor` is used in the `get_n_zeros` function https://github.com/google-research/rigl/blob/476f56a1999febbdfcf3afc4bf5aae0f4855dd32/rigl/sparse_utils.py#L36  

I believe this means if `sparsity * size` equals something like 8.9 (`sparsity=0.89, size=10`),  then get_n_zeros will return 8, instead of 9. It might be a trivial difference, but this could be important for very high sparsities. Not sure if this was intended behaviour? 

I propose using  `return int(round(sparsity * size))` . I proposed something similiar in scipy a while back (https://github.com/scipy/scipy/pull/11784). 